### PR TITLE
Add additional kill options, correct missing double quote

### DIFF
--- a/src/assets/arrays.json
+++ b/src/assets/arrays.json
@@ -163,7 +163,19 @@
         "$mention was a resident of Alderaan before Darth Vader destroyed the planet...",
         "$mention was scooped by $author and their innards are now Ennard.",
         "$author Alt+F4'd $mention.exe!",
-        "$mention was accused of stealing Neptune's crown...'
+        "$mention was accused of stealing Neptune's crown...",
+        "$author eviscerates $mention with a rusty butter knife. Ouch!" 
+        "$author pushes $mention into the cold vaccum of space." 
+        "$author runs $mention over with a PT Cruiser." 
+        "$mention trips over his own shoe laces and dies."
+        "$mention tried to pick out the holy grail. He chose... poorly."
+        "$author hulk smashes $mention into a pulp."
+        "$mention steps on a george foreman and dies of waffle foot."
+        "$mention dies from just being a bad, unlikeable dude."
+        "Calling upon the divine powers, $author smites $mention and their heathen ways"
+        "$mention has a stroke after a sad miserable existence. They are then devoured by their ample cats."
+        "$mention takes an arrow to the knee. And everywhere else."
+        "$mention dies of dysentery."
     ],
     "trumpers": ["http://www.slate.com/content/dam/slate/articles/news_and_politics/politics/2016/04/160422_POL_Donald-Trump-Act.jpg.CROP.promo-xlarge2.jpg", "https://pixel.nymag.com/imgs/daily/intelligencer/2017/01/24/24-trump-unhinged.w710.h473.jpg", "https://blogs-images.forbes.com/robertwood/files/2016/02/Trump1.jpg", "http://static6.businessinsider.com/image/55918b77ecad04a3465a0a63/nbc-fires-donald-trump-after-he-calls-mexicans-rapists-and-drug-runners.jpg", "http://www.slate.com/content/dam/slate/blogs/the_slatest/2017/04/17/trump_recommended_a_book_on_twitter_today_it_has_no_words/660291014-president-donald-trump-speaks-during-an-event.jpg.CROP.promo-xlarge2.jpg", "http://ichef.bbci.co.uk/news/1024/cpsprodpb/1BC2/production/_88160170_trump-promo.jpg", "http://www.slate.com/content/dam/slate/articles/news_and_politics/politics/2017/01/170112_POL_trump.jpg.CROP.promo-xlarge2.jpg"],
     "spinners": [


### PR DESCRIPTION
This PR adds 12 new kill options (Issue #18 ) and corrects a malformed string in the kills array (terminated with a single quote rather than a double quote).